### PR TITLE
Add support for getnameinfo

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -9,7 +9,9 @@ from typing import (
     Any,
     Optional,
     Set,
-    Sequence
+    Sequence,
+    Tuple,
+    Union
 )
 
 from . import error
@@ -115,6 +117,12 @@ class DNSResolver:
         fut = asyncio.Future(loop=self.loop)  # type: asyncio.Future
         cb = functools.partial(self._callback, fut)
         self._channel.getaddrinfo(host, port, cb, family=family, type=type, proto=proto, flags=flags)
+        return fut
+
+    def getnameinfo(self, sockaddr: Union[Tuple[str, int], Tuple[str, int, int, int]], flags: int = 0) -> asyncio.Future:
+        fut = asyncio.Future(loop=self.loop)  # type: asyncio.Future
+        cb = functools.partial(self._callback, fut)
+        self._channel.getnameinfo(sockaddr, flags, cb)
         return fut
 
     def gethostbyaddr(self, name: str) -> asyncio.Future:

--- a/tests.py
+++ b/tests.py
@@ -169,6 +169,18 @@ class DNSTest(unittest.TestCase):
         self.assertTrue(result)
         self.assertTrue(all(node.family == socket.AF_INET6 for node in result.nodes))
 
+    def test_getnameinfo_ipv4(self):
+        f = self.resolver.getnameinfo(('127.0.0.1', 0))
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertTrue(result.node)
+
+    def test_getnameinfo_ipv6(self):
+        f = self.resolver.getnameinfo(('::1', 0, 0, 0))
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertTrue(result.node)
+
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr(self):
         f = self.resolver.gethostbyaddr('127.0.0.1')


### PR DESCRIPTION
This is a followup to #118 to add `getnameinfo` as well to support

https://github.com/aio-libs/aiohttp/pull/8270